### PR TITLE
Fixes warning when building all targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+# IDE files
+.idea

--- a/examples/utils/mod.rs
+++ b/examples/utils/mod.rs
@@ -4,4 +4,7 @@ pub mod rpc_client;
 pub mod transaction;
 
 pub use args::parse_inputs;
+
+// Not all examples use these
+#[allow(unused_imports)]
 pub use fee::{calc_fees, Fees};


### PR DESCRIPTION
When --all-targets or tests are built, or one of the examples, there is a warning. This PR fixes that.