### PR TITLE
Fix issues with random number generation in WASM build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,20 +10,14 @@ documentation = "https://docs.rs/ord-rs"
 edition = "2021"
 
 [dependencies]
-log = "0.4"
-
-# rand = { version = "0.8", features = ["std_rng", "small_rng"] }
 bitcoin = { version = "0.31", features = ["rand"] }
 getrandom = { version = "0.2", features = ["custom"] }
+log = "0.4"
 rand = { version = "0.8.5", features = ["getrandom"] }
-
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_with = { version = "3", default-features = false, features = ["macros"] }
 thiserror = "1"
-
-# [target."cfg(target_arch = \"wasm32\")".dependencies]
-# getrandom = { version = "0.2", features = ["js"] }
 
 [dev-dependencies]
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,8 @@ edition = "2021"
 
 [dependencies]
 bitcoin = { version = "0.31", features = ["rand"] }
-# getrandom = { version = "0.2", features = ["custom"] }
 log = "0.4"
-rand = { version = "0.8.5" }
+rand = { version = "0.8" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_with = { version = "3", default-features = false, features = ["macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,16 +10,20 @@ documentation = "https://docs.rs/ord-rs"
 edition = "2021"
 
 [dependencies]
-bitcoin = { version = "0.31", features = ["rand"] }
 log = "0.4"
-rand = { version = "0.8", features = ["std_rng", "small_rng"] }
+
+# rand = { version = "0.8", features = ["std_rng", "small_rng"] }
+bitcoin = { version = "0.31", features = ["rand"] }
+getrandom = { version = "0.2", features = ["custom"] }
+rand = { version = "0.8.5", features = ["getrandom"] }
+
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_with = { version = "3", default-features = false, features = ["macros"] }
 thiserror = "1"
 
-[target."cfg(target_arch = \"wasm32\")".dependencies]
-getrandom = { version = "0.2", features = ["js"] }
+# [target."cfg(target_arch = \"wasm32\")".dependencies]
+# getrandom = { version = "0.2", features = ["js"] }
 
 [dev-dependencies]
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ edition = "2021"
 
 [dependencies]
 bitcoin = { version = "0.31", features = ["rand"] }
-getrandom = { version = "0.2", features = ["custom"] }
+# getrandom = { version = "0.2", features = ["custom"] }
 log = "0.4"
-rand = { version = "0.8.5", features = ["getrandom"] }
+rand = { version = "0.8.5" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_with = { version = "3", default-features = false, features = ["macros"] }


### PR DESCRIPTION
Enabling the `js` feature in `getrandom` introduces a myriad of issues when this library is used as a dependency in canister development, especially while attempting to generate `.did` files using the `candid-extractor` tool. This issue stems from the fact that generating randomness on IC works a little differently.

Changing from the `js` feature to the `custom` feature (i.e. `getrandom = { version = "0.2", features = ["custom"] }`) allows one to introduce a custom random number generator implementation in any canister. This PR effects exactly that change!

Without this change, attempting to generate the `.did` file in a Rust canister that uses this library will result in an error that looks like this: `Error: unknown import: wbindgen_placeholder::__wbindgen_describe has not been defined`.

[Reference](https://forum.dfinity.org/t/module-imports-function-wbindgen-describe-from-wbindgen-placeholder-that-is-not-exported-by-the-runtime/11545)