### PR TITLE
Fix: Implement `Inscription::content_type` for `Nft`

### DIFF
--- a/src/inscription.rs
+++ b/src/inscription.rs
@@ -3,37 +3,64 @@ pub mod nft;
 
 use bitcoin::script::PushBytesBuf;
 use serde::de::DeserializeOwned;
+use serde::Serialize;
 
-use crate::OrdResult;
+use crate::{OrdError, OrdResult};
 
-/// The inscription trait is used to write data to the redeem script of a commit and reveal transaction.
+/// The `Inscription` trait defines the behavior necessary for handling
+/// Bitcoin Ordinal inscriptions within the context of commit and reveal transactions.
+///
+/// These are methods for encoding, decoding, and managing
+/// the inscriptions, tailored to specific types (e.g. `Brc20`, `Nft`).
 pub trait Inscription: DeserializeOwned {
-    /// Returns the content type of the inscription.
+    /// Encodes the inscription object into a JSON string.
+    ///
+    /// # Errors
+    ///
+    /// May return an `OrdError` if serialization fails.
+    fn encode(&self) -> OrdResult<String>
+    where
+        Self: Serialize,
+    {
+        serde_json::to_string(self).map_err(OrdError::from)
+    }
+
+    /// Returns the MIME content type of the inscription.
+    ///
+    /// It should provide the MIME type string that best represents the
+    /// data format of the inscription (e.g., "text/plain;charset=utf-8", "application/json").
     fn content_type(&self) -> String;
 
-    /// Returns the inscription as to be pushed to the redeem script.
+    /// Returns the body of the inscription as to be pushed to the redeem script.
     ///
-    /// This data follows the header of the inscription:
+    /// This body must follow the header of the inscription as presented below:
     ///
-    /// - public key
-    /// - OP_CHECKSIG
-    /// - OP_FALSE
-    /// - OP_IF
-    /// - ord
-    /// - 0x01
-    /// - {inscription.content_type()}
-    /// - 0x00
+    /// Header:
+    ///   - Public key
+    ///   - OP_CHECKSIG
+    ///   - OP_FALSE
+    ///   - OP_IF
+    ///   - "ord" (the opcode or marker indicating an ordinal inscription)
+    ///   - 0x01 (version byte)
+    ///   - {self.content_type()}
+    ///   - 0x00 (separator byte)
     ///
-    /// then it comes your data
+    /// Next is the inscription data/body (payload)
     ///
-    /// and then the footer:
-    ///
-    /// - OP_ENDIF
+    /// Then comes the footer:
+    ///   - OP_ENDIF
     ///
     /// So for example in case of a BRC20, this function must return the JSON encoded BRC20 operation as `PushBytes`.
     fn data(&self) -> OrdResult<PushBytesBuf>;
 
-    /// Returns the inscription data from the serialized inscription bytes in the witness script.
+    /// Parses inscription data from the serialized bytes found in the witness script.
+    ///
+    /// Decodes the inscription data embedded within the witness script of
+    /// a Bitcoin transaction, reconstructing the original inscription object.
+    ///
+    /// # Errors
+    ///
+    /// May return an `OrdError` if parsing fails.
     fn parse(data: &[u8]) -> OrdResult<Self>
     where
         Self: Sized;

--- a/src/inscription/brc20.rs
+++ b/src/inscription/brc20.rs
@@ -52,11 +52,6 @@ impl Brc20 {
             amt,
         })
     }
-
-    /// Encode the BRC-20 operation as a JSON string
-    pub fn encode(&self) -> OrdResult<String> {
-        serde_json::to_string(self).map_err(OrdError::from)
-    }
 }
 
 impl FromStr for Brc20 {

--- a/src/inscription/nft.rs
+++ b/src/inscription/nft.rs
@@ -67,7 +67,10 @@ pub struct Nft {
 
 impl Inscription for Nft {
     fn content_type(&self) -> String {
-        unimplemented!()
+        match self.content_type() {
+            Some(t) => t.to_string(),
+            None => "".to_string(),
+        }
     }
 
     fn data(&self) -> OrdResult<PushBytesBuf> {
@@ -163,11 +166,6 @@ impl Nft {
         }
 
         builder.push_opcode(opcodes::all::OP_ENDIF)
-    }
-
-    /// Encodes `Self` as a JSON string.
-    pub fn encode(&self) -> OrdResult<String> {
-        Ok(serde_json::to_string(self)?)
     }
 
     /// Creates a new `Nft` from JSON-encoded string.


### PR DESCRIPTION
## Changes
<!-- Please describe in detail the changes made -->
- [x] Implemented `Inscription::content_type` for `Nft`
- [x] Extracted shared `encode` method into trait
- [x] Minor improvement in docs
