### PR TITLE
Make `TxInputInfo` struct public

### DIFF
--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -5,6 +5,6 @@ pub use builder::signer::{ExternalSigner, Wallet, WalletType};
 pub use builder::{
     CreateCommitTransaction, CreateCommitTransactionArgs, CreateCommitTransactionArgsV2,
     OrdTransactionBuilder, RedeemScriptPubkey, RevealTransactionArgs, ScriptType,
-    SignCommitTransactionArgs, Utxo,
+    SignCommitTransactionArgs, TxInputInfo, Utxo,
 };
 pub use parser::OrdParser;


### PR DESCRIPTION
Quick fix for the previous PR. For some reason clippy didn't catch that the `sign_transaction` method gets an input of a non-public type.
